### PR TITLE
Restricts cell identification ellipses to annotated regions

### DIFF
--- a/src/components/Predict.jsx
+++ b/src/components/Predict.jsx
@@ -34,7 +34,7 @@ function predictAnnotation(openseadragon, classifier, annotation, saveTilePredic
   let result = Map();
   let process_and_store_tile = (tile, img_data) => { 
     // predict for tile
-    const tile_overlay = predictTile(tile, img_data, classifier);
+    const tile_overlay = predictTile(tile, img_data, classifier, annotation);
 
     // render and add overlay to openseadragon viewer
     if (show_superpixels) {
@@ -65,6 +65,7 @@ function predictAnnotation(openseadragon, classifier, annotation, saveTilePredic
   for (let x=min_tile.x; x<=max_tile.x; x++) {
     for (let y=min_tile.y; y<=max_tile.y; y++) {
       const tile = create_tile(x, y, level, tile_source, openseadragon.drawer.context);
+      // Shouldn't test if tile corners are in annotation; if an annotation intersects a tile but all corners are outside then we currently don't detect it
       if (inPolygon(polygon.toJS(), tile.bounds)) {
         load_and_process_tile(tiled_image, tile, process_and_store_tile);
       }
@@ -74,7 +75,7 @@ function predictAnnotation(openseadragon, classifier, annotation, saveTilePredic
 }
 
 // called when a new tile is loaded
-function predictTile(tile, img_data, classifier) {
+function predictTile(tile, img_data, classifier, annotation) {
   // SLIC the image data
   const superpixel_size = classifier.get('superpixel_size');
   const [
@@ -100,7 +101,7 @@ function predictTile(tile, img_data, classifier) {
   classifier.get('svm').predict(features).map((x, idx) => {
     tile_overlay.add_classification(idx, (x > 0 ? 1 : -1));
   });
-  return new TileCellData(tile_overlay);
+  return new TileCellData(tile_overlay,annotation);
 }
 
 

--- a/src/util/TileCellData.js
+++ b/src/util/TileCellData.js
@@ -193,16 +193,12 @@ export default class TileCellData {
         // Need to map point (in tile coords) to annotation (in % of image)
         let scale = this.tile.bounds.height / this.tile.sourceBounds.height;
 
-        // let shift_x = (this.tile.x) * this.tile.bounds.width;
-        // let shift_y = (this.tile.y) * this.tile.bounds.height;
         let shift_x = this.tile.x * this.tile.bounds.x / this.tile.x;
         let shift_y = this.tile.y * this.tile.bounds.y / this.tile.y;
 
-        // test if ellipse centroid is contained in the annotation polygon
-
         let point = new OpenSeadragon.Point(shift_x + rotatedRect.center.x * scale, shift_y + rotatedRect.center.y * scale);
 
-        // Only add ellipse to data if point is inside
+        // Only add ellipse to data if point is inside annotation polygon
         if (isInside(polygon.toJS(),polygon.size,point)) {
 
           // add ellipse to data

--- a/src/util/TileCellData.js
+++ b/src/util/TileCellData.js
@@ -1,8 +1,11 @@
 import cv from 'opencv.js';
 const { List } = require("immutable");
+import { isInside } from './geometry.js';
+import OpenSeadragon from "openseadragon";
 
 export default class TileCellData {
-  constructor(superpixel_classification) {
+  constructor(superpixel_classification,annotation) {
+    this.annotation = annotation;
     this.id = superpixel_classification.tile.cacheKey;
     this.tile = superpixel_classification.tile;
     this.superpixel_classification = superpixel_classification;
@@ -25,7 +28,7 @@ export default class TileCellData {
 
 
   copy() {
-    let c = new TileCellData(this.superpixel_classification.copy());
+    let c = new TileCellData(this.superpixel_classification.copy(),this.annotation);
     c.centroids_x = this.centroids_x
     c.centroids_y = this.centroids_y
     c.widths = this.widths;
@@ -172,6 +175,10 @@ export default class TileCellData {
     //  console.log(`iteration max area is ${max_area}`);
     //}
     //console.log(`final max area is ${max_area}`);
+
+    // Get easy access to the polygon
+    let polygon = this.annotation.get('polygon');
+
     cv.findContours(mask, contours, hierarchy, cv.RETR_TREE, cv.CHAIN_APPROX_SIMPLE);
 
     for (let i = 0; i < contours.size(); ++i) {
@@ -182,11 +189,29 @@ export default class TileCellData {
       if (cell_area > 10) {
         // fit an ellipse
         const rotatedRect = cv.fitEllipse(contours.get(i));
-        // add ellipse to data
-        this.add_cell(rotatedRect.center.x, rotatedRect.center.y, rotatedRect.size.width, rotatedRect.size.height, rotatedRect.angle);
+
+        // Need to map point (in tile coords) to annotation (in % of image)
+        let scale = this.tile.bounds.height / this.tile.sourceBounds.height;
+
+        // let shift_x = (this.tile.x) * this.tile.bounds.width;
+        // let shift_y = (this.tile.y) * this.tile.bounds.height;
+        let shift_x = this.tile.x * this.tile.bounds.x / this.tile.x;
+        let shift_y = this.tile.y * this.tile.bounds.y / this.tile.y;
+
+        // test if ellipse centroid is contained in the annotation polygon
+
+        let point = new OpenSeadragon.Point(shift_x + rotatedRect.center.x * scale, shift_y + rotatedRect.center.y * scale);
+
+        // Only add ellipse to data if point is inside
+        if (isInside(polygon.toJS(),polygon.size,point)) {
+
+          // add ellipse to data
+          this.add_cell(rotatedRect.center.x, rotatedRect.center.y, rotatedRect.size.width, rotatedRect.size.height, rotatedRect.angle);
+        }
       }
     }
-  
+
+
     console.log(`finished segmenting, found ${this.centroids_x.size} cells`);
 
     mask.delete();

--- a/src/util/geometry.js
+++ b/src/util/geometry.js
@@ -57,7 +57,7 @@ function doIntersect(p1, q1, p2, q2) {
 } 
   
 // Returns true if the point p lies inside the polygon[] with n vertices 
-function isInside(polygon, n, p) { 
+export function isInside(polygon, n, p) {
     // There must be at least 3 vertices in polygon[] 
     if (n < 3)  return false; 
   


### PR DESCRIPTION
Only draws ellipses if ellipse centroid is inside annotated region. (Hopefully)